### PR TITLE
Filesystem backend

### DIFF
--- a/lazy_build/cache.py
+++ b/lazy_build/cache.py
@@ -5,6 +5,8 @@ import tempfile
 import boto3
 import botocore
 
+from lazy_build import util
+
 
 ArtifactDetails = collections.namedtuple('ArtifactDetails', ('size',))
 
@@ -17,20 +19,20 @@ class S3Backend(collections.namedtuple('S3Backend', (
     __slots__ = ()
 
     @property
-    def s3(self):
+    def _s3(self):
         return boto3.resource('s3')
 
-    def key_for_ctx(self, ctx):
+    def _key_for_ctx(self, ctx):
         return self.path.rstrip('/') + '/' + ctx.hash
 
-    def artifact_paths(self, ctx):
-        key = self.key_for_ctx(ctx)
-        return key + '.tar.gz', key + '.json'
+    def _artifact_paths(self, ctx):
+        key = self._key_for_ctx(ctx)
+        return f'{key}.tar', f'{key}.json'
 
     def artifact_details(self, ctx):
-        tarball, json = self.artifact_paths(ctx)
+        tarball, json = self._artifact_paths(ctx)
         try:
-            obj = self.s3.Object(self.bucket, tarball)
+            obj = self._s3.Object(self.bucket, tarball)
             obj.load()
             return ArtifactDetails(obj.content_length)
         except botocore.exceptions.ClientError as ex:
@@ -40,10 +42,10 @@ class S3Backend(collections.namedtuple('S3Backend', (
                 raise
 
     def get_artifact(self, ctx, callback):
-        tarball, json = self.artifact_paths(ctx)
+        tarball, json = self._artifact_paths(ctx)
         fd, path = tempfile.mkstemp()
         os.close(fd)
-        self.s3.meta.client.download_file(
+        self._s3.meta.client.download_file(
             self.bucket,
             tarball,
             path,
@@ -52,13 +54,56 @@ class S3Backend(collections.namedtuple('S3Backend', (
         return path
 
     def store_artifact(self, ctx, path, callback):
-        tarball, json = self.artifact_paths(ctx)
-        self.s3.meta.client.upload_file(
+        tarball, json = self._artifact_paths(ctx)
+        self._s3.meta.client.upload_file(
             path,
             Key=tarball,
             Bucket=self.bucket,
             Callback=callback,
         )
+
+    def invalidate_artifact(self, ctx):
+        raise NotImplementedError()
+
+
+class FilesystemBackend(collections.namedtuple('FilesystemBackend', (
+    'path',
+))):
+
+    __slots__ = ()
+
+    def _path_for_ctx(self, ctx):
+        return self.path.rstrip('/') + '/' + ctx.hash
+
+    def _artifact_paths(self, ctx):
+        key = self._path_for_ctx(ctx)
+        return f'{key}.tar', f'{key}.json'
+
+    def artifact_details(self, ctx):
+        tarball, json = self._artifact_paths(ctx)
+        try:
+            return ArtifactDetails(os.path.getsize(tarball))
+        except FileNotFoundError:
+            return None
+
+    def get_artifact(self, ctx, callback):
+        # TODO: ideally for this backend we wouldn't bother writing the
+        # temporary file in the first place (currently we have to do this
+        # because the code deletes it after restore)
+        tarball, json = self._artifact_paths(ctx)
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as tf:
+            with open(tarball, 'rb') as f:
+                util.copyfileobj(f, tf, callback)
+        return path
+
+    def store_artifact(self, ctx, path, callback):
+        tarball, json = self._artifact_paths(ctx)
+        with util.atomic_write(tarball, 'wb') as dest:
+            # TODO: ideally for this backend we wouldn't bother writing the
+            # temporary file in the first place
+            with open(path, 'rb') as src:
+                util.copyfileobj(src, dest, callback)
 
     def invalidate_artifact(self, ctx):
         raise NotImplementedError()

--- a/lazy_build/config.py
+++ b/lazy_build/config.py
@@ -74,10 +74,8 @@ class Config(collections.namedtuple('Config', (
                         action = arg
                     else:
                         raise UsageError(
-                            'You already specified an action: {}\n'
-                            "You can't specify another: {}".format(
-                                action, arg,
-                            ),
+                            f'You already specified an action: {action}\n'
+                            f"You can't specify another: {arg}"
                         )
                 else:
                     if action is None:
@@ -89,14 +87,14 @@ class Config(collections.namedtuple('Config', (
                         phase = 1
                         if current_option not in options:
                             raise UsageError(
-                                'Unknown option: {}'.format(current_option),
+                                f'Unknown option: {current_option}',
                             )
             elif phase == 1:
                 if parsed is not None:
                     current_option = parsed.group(1)
                     if current_option not in options:
                         raise UsageError(
-                            'Unknown option: {}'.format(current_option),
+                            f'Unknown option: {current_option}',
                         )
                     elif current_option == 'command':
                         phase = 2
@@ -138,6 +136,10 @@ class Config(collections.namedtuple('Config', (
         if conf['cache']['source'] == 's3':
             backend = cache.S3Backend(
                 bucket=conf['cache']['bucket'],
+                path=conf['cache']['path'],
+            )
+        elif conf['cache']['source'] == 'filesystem':
+            backend = cache.FilesystemBackend(
                 path=conf['cache']['path'],
             )
         else:

--- a/lazy_build/util.py
+++ b/lazy_build/util.py
@@ -1,0 +1,33 @@
+import contextlib
+import os
+import os.path
+import tempfile
+
+
+@contextlib.contextmanager
+def atomic_write(path, mode='w'):
+    tmp = tempfile.mktemp(
+        prefix='.' + os.path.basename(path),
+        dir=os.path.dirname(path),
+    )
+    try:
+        with open(tmp, mode) as f:
+            yield f
+    except:
+        os.remove(tmp)
+        raise
+    else:
+        os.rename(tmp, path)
+
+
+def copyfileobj(src, dest, callback):
+    """Copy from one file object to another.
+
+    Based on shutil.copyfileobj, but with a callback.
+    """
+    while True:
+        buf = src.read(16 * 1024)
+        if not buf:
+            break
+        callback(len(buf))
+        dest.write(buf)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
-from unittest import mock
-
 import pytest
 
+from lazy_build import cache
 from lazy_build import config
 
 
@@ -15,6 +14,6 @@ def simple_config():
         command=('touch venv'),
         ignore={'*.py[co]'},
         output={'venv'},
-        backend=mock.Mock(),
+        backend=cache.FilesystemBackend(path='cache'),
         after_download=(),
     )

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,71 @@
+import json
+
+import pytest
+
+from lazy_build import main
+
+
+@pytest.fixture
+def simple_project(tmpdir):
+    tmpdir.join('.lazy-build.json').write(json.dumps({
+        'cache': {
+            'source': 'filesystem',
+            'path': 'cache',
+        },
+    }))
+    tmpdir.join('cache').mkdir()
+    tmpdir.join('input').write('first input\n')
+    tmpdir.join('test.sh').write(
+        'echo ohai\n'
+        'cat input > output1\n'
+        'mkdir -p output2\n'
+        'echo asdf > output2/thing\n'
+    )
+    with tmpdir.as_cwd():
+        yield tmpdir
+
+
+def test_typical_flow(simple_project, capfd):
+    """Test that it correctly caches based on the inputs."""
+    args = (
+        'build',
+        'context=', 'input',
+        'output=', 'output1', 'output2',
+        'command=', 'bash', 'test.sh',
+    )
+
+    def cleanup():
+        simple_project.join('output1').remove()
+        simple_project.join('output2').remove()
+
+    # The first run shouldn't be cached.
+    main.main(args)
+    out, err = capfd.readouterr()
+    assert out == 'ohai\n'
+    assert simple_project.join('output1').read() == 'first input\n'
+    assert simple_project.join('output2', 'thing').read() == 'asdf\n'
+
+    # The second run should be cached.
+    cleanup()
+    main.main(args)
+    out, err = capfd.readouterr()
+    assert out == ''
+    assert simple_project.join('output1').read() == 'first input\n'
+    assert simple_project.join('output2', 'thing').read() == 'asdf\n'
+
+    # If we change the input, it shouldn't be cached anymore.
+    cleanup()
+    simple_project.join('input').write('second input\n')
+    main.main(args)
+    out, err = capfd.readouterr()
+    assert out == 'ohai\n'
+    assert simple_project.join('output1').read() == 'second input\n'
+    assert simple_project.join('output2', 'thing').read() == 'asdf\n'
+
+    # But the next run with the same input should be cached.
+    cleanup()
+    main.main(args)
+    out, err = capfd.readouterr()
+    assert out == ''
+    assert simple_project.join('output1').read() == 'second input\n'
+    assert simple_project.join('output2', 'thing').read() == 'asdf\n'

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,22 @@
+import pytest
+
+from lazy_build import util
+
+
+def test_atomic_write(tmpdir):
+    a = tmpdir.join('a')
+    a.write('sup')
+    with util.atomic_write(a.strpath) as f:
+        f.write('lol')
+    assert a.read() == 'lol'
+
+
+def test_atomic_write_exception(tmpdir):
+    a = tmpdir.join('a')
+    a.write('sup')
+    with pytest.raises(ValueError):
+        with util.atomic_write(a.strpath) as f:
+            f.write('lol')
+            f.flush()
+            raise ValueError('sorry buddy')
+    assert a.read() == 'sup'


### PR DESCRIPTION
Add a simple filesystem backend, and use it to write an integration test.

At the moment this is mostly useful for testing, but it might be cool in the future if you could use it for a shared per-host cache (would need to do something different with the permissions, of course).