### PR TITLE
Start using tox-pip-extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - '3.6'
 dist: trusty
 sudo: false
-install: pip install tox coveralls
+install: pip install tox tox-pip-extensions coveralls
 script: make test
 after_success:
     - coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
-REBUILD_FLAG =
-
 .PHONY: minimal
 minimal: venv
 
 .PHONY: venv
-venv: .venv.touch
-	tox -e venv $(REBUILD_FLAG)
+venv:
+	tox -e venv
 
 .PHONY: release
 release: venv
@@ -13,12 +11,8 @@ release: venv
 	venv/bin/twine upload --skip-existing dist/*
 
 .PHONY: test
-test: .venv.tox.touch
-	tox $(REBUILD_FLAG)
-
-.venv.touch .venv.tox.touch: setup.py requirements-dev.txt
-	$(eval REBUILD_FLAG := --recreate)
-	touch "$@"
+test:
+	tox
 
 .PHONY: clean
 clean:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py36
+tox_pip_extensions_ext_venv_update = true
+tox_pip_extensions_ext_pip_custom_platform = true
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Don't really need pip-custom-platform since there are (currently) no binary dependencies (and even if there were, this uses public PyPI), but it probably doesn't hurt.

venv-update lets us get rid of the REBUILD_FLAG hack though.